### PR TITLE
Use `ProgramFiles(x86)` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,15 @@ Reasonable defaults are provided (but could be changed by using configuration fi
 
 ```
 gpg:
-  install_path: "${HOMEDRIVE}\Program Files (x86)\gnupg"
+  install_path: "${ProgramFiles(x86)}\\gnupg"
   homedir: "${APPDATA}\\gnupg"
 gui:
   debug: false
   setenv: true
   ignore_session_lock: false
   deadline: 1m
-  pipe_name: \\.\pipe\openssh-ssh-agent
-  homedir: "${LOCALAPPDATA}\gnupg"
+  pipe_name: \\\\.\\pipe\\openssh-ssh-agent
+  homedir: "${LOCALAPPDATA}\\gnupg"
   gclpr:
     port: 2850
 ```

--- a/config/cfg.go
+++ b/config/cfg.go
@@ -22,7 +22,7 @@ type GPGConfig struct {
 
 var defaultGPGConfig = `
 gpg:
-  install_path: "${HOMEDRIVE}\\Program Files (x86)\\gnupg"
+  install_path: "${ProgramFiles(x86)}\\Program Files (x86)\\gnupg"
   homedir: "${APPDATA}\\gnupg"
 `
 


### PR DESCRIPTION
My homedrive is somewhere else windows enterprise profiles. So you shouldn't refer to this for getting the program files path. Checked to see if there was an easy fix and apparently I have `${ProgramFiles(x86)}` for that.

Also fixed path escaping in the README as I had issues with that too.

Thank you for you efforts in writing bundling it and writing the extensive readme!