### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,16 +100,16 @@ Reasonable defaults are provided (but could be changed by using configuration fi
 
 ```
 gpg:
-  install_path: "${ProgramFiles(x86)}\\gnupg"
-  homedir: "${APPDATA}\\gnupg"
+  install_path: "${ProgramFiles(x86)}\gnupg"
+  homedir: "${APPDATA}\gnupg"
 gui:
   debug: false
   setenv: true
   openssh: native
   ignore_session_lock: false
   deadline: 1m
-  pipe_name: \\\\.\\pipe\\openssh-ssh-agent
-  homedir: "${LOCALAPPDATA}\\gnupg"
+  pipe_name: \\.\pipe\openssh-ssh-agent
+  homedir: "${LOCALAPPDATA}\gnupg"
   gclpr:
     port: 2850
 ```


### PR DESCRIPTION
Backslashes don't need to be doubled in the config file. In fact, I had to remove them in my config for the tool to work.

I love this project more than you can know. In the last week, I've spent countless hours going down paths trying to get things to work that absolutely can't. I don't know why people post projects with procedures that can't possibly work as solutions to the Win<->WSL1/2 problem. I love that your project does what it says it will do.