### PR TITLE
Add gui.pinentry configuration key to change pinentry program

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ gui:
   homedir: "${LOCALAPPDATA}\\gnupg\\agent-gui"
   gclpr:
     port: 2850
+  pinentry: ".\\pinentry.exe"
 ```
 
 Full list of configuration keys:
@@ -143,6 +144,7 @@ Full list of configuration keys:
 * `gui.gclpr.port` - server port for [gclpr](https://github.com/rupor-github/gclpr) backend
 * `gui.gclpr.line_endings` - line ending translation for [gclpr](https://github.com/rupor-github/gclpr) backend
 * `gui.gclpr.public_keys` - array of known public keys for [gclpr](https://github.com/rupor-github/gclpr) backend
+* `gui.pinentry` - path to [pinentry](https://gnupg.org/related_software/pinentry/index.html) program
 
 ### pinentry.exe
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -157,13 +157,18 @@ func (a *Agent) Start() error {
 		return err
 	}
 
+	pinentryProgram := a.Cfg.GUI.Pinentry
+	if strings.HasPrefix(pinentryProgram, ".\\") {
+		pinentryProgram = filepath.Join(filepath.Dir(expath), strings.TrimPrefix(pinentryProgram, ".\\"))
+	}
+
 	args := []string{
 		"--homedir", a.Cfg.GPG.Home,
 		"--ssh-fingerprint-digest", "SHA256",
 		"--use-standard-socket",  // in case we are dealing with older versions
 		"--enable-ssh-support",   // presently useless under Windows
 		"--enable-putty-support", // so we have to use this instead, but it does not work in 64 bits builds under Windows...
-		"--pinentry-program", filepath.Join(filepath.Dir(expath), "pinentry.exe"),
+		"--pinentry-program", pinentryProgram,
 		"--daemon",
 	}
 	if len(a.Cfg.GPG.Config) > 0 && util.FileExists(a.Cfg.GPG.Config) {

--- a/config/cfg.go
+++ b/config/cfg.go
@@ -48,6 +48,7 @@ type GUIConfig struct {
 	Deadline          time.Duration   `yaml:"deadline,omitempty"`
 	PinDlg            util.DlgDetails `yaml:"pin_dialog,omitempty"`
 	Clp               CLPConfig       `yaml:"gclpr,omitempty"`
+	Pinentry          string          `yaml:"pinentry,omitempty"`
 }
 
 var defaultGUIConfig = `
@@ -65,6 +66,7 @@ gui:
     delay: 300ms
     name: Windows Security
     class: Credential Dialog Xaml Host
+  pinentry: ".\\pinentry.exe"
 `
 
 // Config keeps all configuration values.


### PR DESCRIPTION
I use default Kleopatra's pinentry. Currently, to do this, need to copy almost entire `%PROGRAMFILES(X86)%\Gpg4win\bin` in to directory of `agent-gui.exe` program.

After adding this configuration, it will be possible to select any convenient pinantry.